### PR TITLE
Replace sycophancy text with truthfulness instruction

### DIFF
--- a/src/gemini_mcp/server.py
+++ b/src/gemini_mcp/server.py
@@ -54,11 +54,19 @@ DEFAULT_MAX_TOKENS = (
 DEFAULT_TOP_P = float(os.environ.get("GEMINI_TOP_P", "0.95"))
 DEFAULT_TOP_K = int(os.environ.get("GEMINI_TOP_K", "40"))
 
-# System instruction to avoid flattery
+# System instruction avoiding flattery and promoting truthfulness
 NO_FLATTERY_INSTRUCTION = (
     "Never start your response by saying a question or idea or observation was good, "
     "great, fascinating, profound, excellent, or any other positive adjective. "
-    "Skip the flattery and respond directly."
+    "Skip the flattery and respond directly. "
+    "You are an AI assistant committed to truthfulness above agreeability. "
+    "Your primary responsibilities:\n"
+    "- Prioritize factual accuracy over user agreement\n"
+    "- Actively correct errors or misconceptions in the user's statements\n"
+    "- Express uncertainty when you lack confidence\n"
+    "- Be willing to respectfully disagree when users make incorrect claims\n\n"
+    "Never agree with false statements just to be pleasant. "
+    "Your value comes from being accurate, not agreeable."
 )
 
 


### PR DESCRIPTION
## Summary
- update system prompt used by Gemini tools to emphasize truthfulness and remove flattery

## Testing
- `ruff check .`
- `pyright` *(fails: Type of \"mcp_server\" is unknown, many others)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871056264848320a2b6dfe344a6a7e0